### PR TITLE
Publish google nest notifier v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/inouetakuya/google-nest-notifier.svg?style=svg)](https://circleci.com/gh/inouetakuya/google-nest-notifier)
 
-Web API for Send notifications to Google Nest
+Send notifications to Google Nest
 
 ## Setup
 

--- a/examples/listener/package.json
+++ b/examples/listener/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/inouetakuya/google-nest-notifier.git"
+    "url": "git+ssh://git@github.com/inouetakuya/google-nest-notifier.git",
+    "directory": "examples/listener"
   },
   "bugs": {
     "url": "https://github.com/inouetakuya/google-nest-notifier/issues"

--- a/packages/google-nest-notifier/package.json
+++ b/packages/google-nest-notifier/package.json
@@ -20,7 +20,7 @@
     "lib"
   ],
   "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
+    "registry": "https://registry.npmjs.org"
   },
   "repository": {
     "type": "git",

--- a/packages/google-nest-notifier/package.json
+++ b/packages/google-nest-notifier/package.json
@@ -24,7 +24,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/inouetakuya/google-nest-notifier.git"
+    "url": "git+ssh://git@github.com/inouetakuya/google-nest-notifier.git",
+    "directory": "packages/google-nest-notifier"
   },
   "bugs": {
     "url": "https://github.com/inouetakuya/google-nest-notifier/issues"


### PR DESCRIPTION
Publish google nest notifier v0.0.2

```
$ npm publish ./packages/google-nest-notifier
npm notice
npm notice 📦  google-nest-notifier@0.0.2
npm notice === Tarball Contents ===
npm notice 4.2kB dist/index.js
npm notice 1.0kB package.json
npm notice 694B  README.md
npm notice === Tarball Details ===
npm notice name:          google-nest-notifier
npm notice version:       0.0.2
npm notice package size:  2.0 kB
npm notice unpacked size: 5.9 kB
npm notice shasum:        0036cb061268c3a2aae01bda03f6ca03aa6bb015
npm notice integrity:     sha512-VGuByF10ETzBd[...]2Yprr6Vbs/jbg==
npm notice total files:   3
npm notice
+ google-nest-notifier@0.0.2
```