### PR TITLE
fix: "types" property of package.json

### DIFF
--- a/packages/google-nest-notifier/package.json
+++ b/packages/google-nest-notifier/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/inouetakuya/google-nest-notifier#readme",
   "license": "MIT",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Related

- [fix: publishing declaration files by inouetakuya · Pull Request #68 · inouetakuya/google-nest-notifier](https://github.com/inouetakuya/google-nest-notifier/pull/68)