### PR TITLE
fix: yarn workspace listener dev

### DIFF
--- a/examples/listener/package.json
+++ b/examples/listener/package.json
@@ -43,7 +43,7 @@
     "@hapi/boom": "^9.1.2",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "google-nest-notifier": "^0.0.2",
+    "google-nest-notifier": "^0.0.3",
     "morgan": "^1.10.0",
     "ngrok": "4.0.1",
     "pm2": "^5.2.0",

--- a/examples/listener/package.json
+++ b/examples/listener/package.json
@@ -56,6 +56,6 @@
     "@types/supertest": "^2.0.11",
     "nodemon": "^2.0.15",
     "supertest": "^6.1.6",
-    "ts-node": "^10.0.0"
+    "ts-node": "^10.9.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,6 +497,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz#a556790523a351b4e47e9d385f47265eaaf9780a"
@@ -836,6 +843,14 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
   integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
 
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@jridgewell/trace-mapping@^0.3.12":
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
@@ -1106,10 +1121,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.0.tgz#5bd046e508b1ee90bc091766758838741fdefd6e"
   integrity sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==
 
-"@tsconfig/node16@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.1.tgz#a6ca6a9a0ff366af433f42f5f0e124794ff6b8f1"
-  integrity sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@types/babel__core@^7.1.14":
   version "7.1.16"
@@ -1451,10 +1466,15 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.2.0:
+acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 acorn@^8.7.0, acorn@^8.8.0:
   version "8.8.0"
@@ -5179,7 +5199,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@0.5.19, source-map-support@^0.5.17:
+source-map-support@0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -5436,20 +5456,23 @@ ts-jest@29.0.5:
     semver "7.x"
     yargs-parser "^21.0.1"
 
-ts-node@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.0.0.tgz#05f10b9a716b0b624129ad44f0ea05dac84ba3be"
-  integrity sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
     "@tsconfig/node12" "^1.0.7"
     "@tsconfig/node14" "^1.0.0"
-    "@tsconfig/node16" "^1.0.1"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 tslib@1.9.3:
@@ -5605,6 +5628,11 @@ uuid@^3.2.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,20 +3029,6 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-google-nest-notifier@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/google-nest-notifier/-/google-nest-notifier-0.0.2.tgz#0036cb061268c3a2aae01bda03f6ca03aa6bb015"
-  integrity sha512-VGuByF10ETzBd+VNW8Coue/b9WOJEMH6OYtr760WwN1fedEsQjDq7/lCF8fZdVZ6U/4nIytIf2Yprr6Vbs/jbg==
-  dependencies:
-    castv2-client "^1.2.0"
-    google-tts-api "^0.0.6"
-    mdns-js "^1.0.3"
-
-google-tts-api@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/google-tts-api/-/google-tts-api-0.0.6.tgz#3e8509caf066e09f6166b7e5e2816a374a7899d3"
-  integrity sha512-Tt7AOwQ6HkVlhOylYYyHzmCvharwLov1Mrrq6RogtRwQzGCPpnrR6Um7Bcx3xlXYHJX0wcLGFW9RuJIFxXYcaQ==
-
 google-tts-api@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/google-tts-api/-/google-tts-api-2.0.2.tgz#5f02bbde9b41f57569a94a3dd1d2de808a97bb97"


### PR DESCRIPTION
```
$ yarn workspace listener dev
yarn workspace v1.22.19
yarn run v1.22.19
$ nodemon
[nodemon] 2.0.15
[nodemon] reading config ./nodemon.json
[nodemon] to restart at any time, enter `rs`
[nodemon] or send SIGHUP to 15807 to restart
[nodemon] watching path(s): src/**/*
[nodemon] watching extensions: ts
[nodemon] starting `ts-node ./src/index.ts`
[nodemon] spawning
[nodemon] child pid: 15833
[nodemon] watching 7 files

/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:43500
        ts.Debug.assert(typeof typeReferenceDirectiveName === "string", "Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.");
                 ^
Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
    at Object.resolveTypeReferenceDirective (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:43500:18)
    at /Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/ts-node/src/index.ts:737:16
    at Array.map (<anonymous>)
    at Object.resolveTypeReferenceDirectives (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/ts-node/src/index.ts:734:33)
    at actualResolveTypeReferenceDirectiveNamesWorker (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:119382:163)
    at resolveTypeReferenceDirectiveNamesWorker (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:119682:26)
    at processTypeReferenceDirectives (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:121185:31)
    at findSourceFileWorker (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:121070:21)
    at findSourceFile (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:120922:26)
    at processImportedModules (/Users/inouetakuya/src/github.com/inouetakuya/google-nest-notifier/node_modules/typescript/lib/typescript.js:121331:25)
[nodemon] app crashed - waiting for file changes before starting...
```
