### PR TITLE
Publish google-nest-notifier 0.0.4

### DIFF
--- a/examples/listener/package.json
+++ b/examples/listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listener",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Listener for google-nest-notifier",
   "author": "INOUE Takuya <inouetakuya5@gmail.com>",
   "homepage": "https://github.com/inouetakuya/google-nest-notifier#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-nest-notifier-workspaces",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Workspaces for google-nest-notifier",
   "author": "INOUE Takuya <inouetakuya5@gmail.com>",
   "license": "MIT",

--- a/packages/google-nest-notifier/package.json
+++ b/packages/google-nest-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-nest-notifier",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Send notifications to Google Nest",
   "keywords": [
     "google nest",


### PR DESCRIPTION
```
yarn version --patch --no-git-tag-version --no-commit-hooks
yarn workspace google-nest-notifier version --patch --no-git-tag-version --no-commit-hooks
yarn workspace listener version --patch --no-git-tag-version --no-commit-hooks
```

```
git add .
git commit -m "version 0.0.4"
git log
```

## Publish

```
yarn workspace google-nest-notifier publish --no-git-tag-version --no-commit-hooks
```

## Push tag

```
git tag v0.0.4
git push origin v0.0.4
```

## Refs

- [Publish google-nest-notifier v0.0.3 by inouetakuya · Pull Request #70 · inouetakuya/google-nest-notifier](https://github.com/inouetakuya/google-nest-notifier/pull/70)
