### PR TITLE
Publish 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## main
+## [0.0.6](https://github.com/inouetakuya/google-nest-notifier/compare/v0.0.5...v0.0.6) (2024-10-11)
+
+### Chores
+
+- Bump Node.js to v20
+- Update dependencies
 
 ## [0.0.5](https://github.com/inouetakuya/google-nest-notifier/compare/v0.0.4...v0.0.5) (2023-12-31)
 

--- a/examples/listener/package.json
+++ b/examples/listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listener",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Listener for google-nest-notifier",
   "author": "INOUE Takuya <inouetakuya5@gmail.com>",
   "homepage": "https://github.com/inouetakuya/google-nest-notifier#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-nest-notifier-workspaces",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Workspaces for google-nest-notifier",
   "author": "INOUE Takuya <inouetakuya5@gmail.com>",
   "license": "MIT",

--- a/packages/google-nest-notifier/package.json
+++ b/packages/google-nest-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-nest-notifier",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Send notifications to Google Nest",
   "keywords": [
     "google nest",


### PR DESCRIPTION
## npm authorization

> npm error code ENEEDAUTH
> npm error need auth This command requires you to be logged in to https://registry.npmjs.org
> npm error need auth You need to authorize this machine using `npm adduser`
> npm error A complete log of this run can be found in: /Users/inouetakuya/.npm/_logs/2024-10-11T12_41_22_813Z-debug-0.log

```
npm adduser
```

## Bump version

```
yarn version --patch --no-git-tag-version --no-commit-hooks
yarn workspace google-nest-notifier version --patch --no-git-tag-version --no-commit-hooks
yarn workspace listener version --patch --no-git-tag-version --no-commit-hooks
```

```
git add .
git commit -m "version 0.0.6"
git log
```

## Publish

```
yarn workspace google-nest-notifier publish --no-git-tag-version --no-commit-hooks
```

## Push tag

```
git tag 0.0.6
git push origin 0.0.6
```

## Refs

- [Publish google-nest-notifier 0.0.5 by inouetakuya · Pull Request #296 · inouetakuya/google-nest-notifier](https://github.com/inouetakuya/google-nest-notifier/pull/296)
