### PR TITLE
ci: Fix ESLintRCWarning that occur when Reviewdog runs ESLint

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,7 +1,7 @@
 name: reviewdog
 on: [pull_request]
 env:
-  ESLINT_USE_FLAT_CONFIG: false
+  ESLINT_USE_FLAT_CONFIG: true
 jobs:
   eslint:
     name: runner / eslint

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,7 +1,5 @@
 name: reviewdog
 on: [pull_request]
-env:
-  ESLINT_USE_FLAT_CONFIG: true
 jobs:
   eslint:
     name: runner / eslint
@@ -15,10 +13,9 @@ jobs:
       - run: yarn workspace google-nest-notifier build
       - run: yarn install
       - name: eslint
-        uses: reviewdog/action-eslint@v1.32.0
+        uses: reviewdog/action-eslint@v1
         with:
           level: warning
           reporter: github-pr-review
           filter_mode: nofilter
           fail_on_error: false # because level is warning
-          eslint_flags: '--config eslint.config.mjs'

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,3 +21,4 @@ jobs:
           reporter: github-pr-review
           filter_mode: nofilter
           fail_on_error: false # because level is warning
+          eslint_flags: '--config eslint.config.mjs'

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,7 +15,7 @@ jobs:
       - run: yarn workspace google-nest-notifier build
       - run: yarn install
       - name: eslint
-        uses: reviewdog/action-eslint@v1
+        uses: reviewdog/action-eslint@v1.32.0
         with:
           level: warning
           reporter: github-pr-review


### PR DESCRIPTION
reviewdog/reviewdog: 🐶 Automated code review tool integrated with any code analysis tools regardless of programming language
https://github.com/reviewdog/reviewdog

## Error log

https://github.com/inouetakuya/google-nest-notifier/actions/runs/11304647507/job/31443268111

```
Run reviewdog/action-eslint@v1
Run $GITHUB_ACTION_PATH/script.sh
🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog
v9.12.0
(node:2068) ESLintRCWarning: You are using an eslintrc configuration file, which is deprecated and support will be removed in v10.0.0. Please migrate to an eslint.config.js file. See https://eslint.org/docs/latest/use/configure/migration-guide for details.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:2087) ESLintRCWarning: You are using an eslintrc configuration file, which is deprecated and support will be removed in v10.0.0. Please migrate to an eslint.config.js file. See https://eslint.org/docs/latest/use/configure/migration-guide for details.
(Use `node --trace-warnings ...` to show where the warning was created)
eslint version:v9.12.0
 Running eslint with reviewdog 🐶 ...
  
  Oops! Something went wrong! :(
  
  ESLint: 9.12.0
  
  ESLint couldn't find a configuration file. To set up a configuration file for this project, please run:
  
      npm init @eslint/config@latest
  
  ESLint looked for configuration files in /home/runner/work/google-nest-notifier/google-nest-notifier/examples/listener and its ancestors. If it found none, it then looked in your home directory.
  
  If you think you already have a configuration file or if you need more help, please stop by the ESLint Discord server: https://eslint.org/chat
  
  (node:2111) ESLintRCWarning: You are using an eslintrc configuration file, which is deprecated and support will be removed in v10.0.0. Please migrate to an eslint.config.js file. See https://eslint.org/docs/latest/use/configure/migration-guide for details.
  (Use `node --trace-warnings ...` to show where the warning was created)
  reviewdog: parse error: failed to unmarshal rdjson (DiagnosticResult): proto: syntax error (line 1:1): unexpected token 
Error: Process completed with exit code 1.
```