### PR TITLE
Publish 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.0.7](https://github.com/inouetakuya/google-nest-notifier/compare/v0.0.6...v0.0.7) (2024-11-04)
+
+### Chores
+
+- [chore: lock versions of npm packages #370](https://github.com/inouetakuya/google-nest-notifier/pull/370)
+- [Migrate to ESLint Flat Config #373](https://github.com/inouetakuya/google-nest-notifier/pull/373)
+- [chore: Replace Yarn with pnpm #382](https://github.com/inouetakuya/google-nest-notifier/pull/382)
+- [chore: Bump Node.js to v22 #383](https://github.com/inouetakuya/google-nest-notifier/pull/383)
+- Update dependencies
+
 ## [0.0.6](https://github.com/inouetakuya/google-nest-notifier/compare/v0.0.5...v0.0.6) (2024-10-11)
 
 ### Chores

--- a/examples/listener/package.json
+++ b/examples/listener/package.json
@@ -10,9 +10,6 @@
   "directories": {
     "test": "__tests__"
   },
-  "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/inouetakuya/google-nest-notifier.git",

--- a/examples/listener/package.json
+++ b/examples/listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listener",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Listener for google-nest-notifier",
   "author": "INOUE Takuya <inouetakuya5@gmail.com>",
   "homepage": "https://github.com/inouetakuya/google-nest-notifier#readme",
@@ -46,7 +46,7 @@
     "@hapi/boom": "9.1.2",
     "dotenv": "16.4.5",
     "express": "4.20.0",
-    "google-nest-notifier": "0.0.6",
+    "google-nest-notifier": "latest",
     "morgan": "1.10.0",
     "ngrok": "4.0.1",
     "pm2": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-nest-notifier-workspaces",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Workspaces for google-nest-notifier",
   "author": "INOUE Takuya <inouetakuya5@gmail.com>",
   "license": "MIT",

--- a/packages/google-nest-notifier/package.json
+++ b/packages/google-nest-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-nest-notifier",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Send notifications to Google Nest",
   "keywords": [
     "google nest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 4.20.0
         version: 4.20.0
       google-nest-notifier:
-        specifier: 0.0.6
-        version: 0.0.6
+        specifier: latest
+        version: 0.0.7
       morgan:
         specifier: 1.10.0
         version: 1.10.0
@@ -1568,8 +1568,8 @@ packages:
     resolution: {integrity: sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==}
     engines: {node: '>=18'}
 
-  google-nest-notifier@0.0.6:
-    resolution: {integrity: sha512-qwH5aoFTiOH+GlNZAfkOeKWP+IG3Ssp+3CrAX4c+QQPu9PR3Kftj5FFP8bXl3XiISNY6KWnTzfyXdQQJ8pxZyg==}
+  google-nest-notifier@0.0.7:
+    resolution: {integrity: sha512-DRPQb7ohbbQ7pauUxwm5bKI5or8uF3hvVF7tLJKPD8vqIY3VVWDbyLdsMNvLaTozsJ4JIBcBFvmXH/tYGgP1kg==}
 
   google-tts-api@2.0.2:
     resolution: {integrity: sha512-MkQYbBJEdom8hJpfEVDfD3tpBtkz0X59C+FNsoRhbnCiFjZRnzyurGQ5OrAr3xkigII56/jmk0JNwZsp450G+Q==}
@@ -4717,7 +4717,7 @@ snapshots:
 
   globals@15.11.0: {}
 
-  google-nest-notifier@0.0.6:
+  google-nest-notifier@0.0.7:
     dependencies:
       castv2-client: 1.2.0
       google-tts-api: 2.0.2


### PR DESCRIPTION
## npm authorization

```
npm adduser
```

## Bump version

```
pnpm version patch --no-git-tag-version --no-commit-hooks
```

## Publish

```
pnpm --filter google-nest-notifier publish --no-git-checks --ignore-scripts
```

## Push tag

```
git tag 0.0.7
git push origin 0.0.7
```

## Refs

- [Publish 0.0.6 by inouetakuya · Pull Request #369 · inouetakuya/google-nest-notifier](https://github.com/inouetakuya/google-nest-notifier/pull/369)
