### PR TITLE
chore: Renovate が公開から 3日経過したバージョンのみ提案するようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":timezone(Asia/Tokyo)"],
   "schedule": ["after 5am and before 8am on saturday"],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin"],


### PR DESCRIPTION
# 概要

Renovate が公開直後のバージョンで PR を作成すると CI が必ず失敗するため、公開から 3日経過したバージョンのみを提案するようにします。

# 背景

PR #548（eslint を v10.8.1 に更新）で、build ジョブと reviewdog / eslint ジョブの両方が以下のエラーで失敗しました。

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  eslint@10.8.1 was published at 2026-08-07T20:21:24.770Z, within the minimumReleaseAge cutoff (2026-08-06T22:32:07.435Z)
```

pnpm は v11 から `minimumReleaseAge` のデフォルトが 1440分（24時間）となり、公開から 24時間以内のバージョンを含む lockfile は `pnpm install` の supply-chain policy チェックで拒否されます（[pnpm 公式ドキュメント](https://pnpm.io/settings/dependency-resolution)）

CI では `npm install --global pnpm` で最新版をインストールしているため v11 系が入ります。eslint@10.8.1 の公開は 2026-08-07T20:21Z、CI の実行は同日 22:32Z であり、公開から約2時間しか経過していないためポリシーに違反しました。

Renovate 側に待機期間の設定がないと、公開直後のバージョンを拾うたびに同じ失敗が再発します。

# 主な変更点

- renovate.json のトップレベルに `minimumReleaseAge: "3 days"` を追加

pnpm 側のポリシー（24時間）より長い 3日としたのは、Renovate の PR 作成と CI 実行の時刻差による境界での失敗を避けるためです。また不具合のあるリリースが取り下げられる猶予も確保できます。

# 動作確認

`renovate-config-validator` で設定が妥当であることを確認しました。

```
$ npx --yes --package renovate -- renovate-config-validator renovate.json
 INFO: Validating renovate.json as global config
 INFO: Config validated successfully against 1 file(s)
```

# 補足

本 PR は PR #548 の CI 失敗そのものを解消するものではありません。PR #548 は eslint@10.8.1 の公開から 24時間が経過する 2026-08-08T20:21Z（JST 2026-08-09 05:21）以降に CI を再実行すれば通ります。

また `renovate-config-validator` の実行時に、`config:base` が非推奨で `config:recommended` への移行が推奨される旨の警告が出ています。本 PR の範囲外のため対応していません。
